### PR TITLE
Improve tslint.json

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -13,5 +13,11 @@
     "interface-name": false,
     "member-access": [true, "no-public"],
     "ordered-imports": false
+  },
+  "jsRules": {
+    "object-literal-sort-keys": false
+  },
+  "linterOptions": {
+    "exclude": ["public/**/*"]
   }
 }


### PR DESCRIPTION
1. La commande `yarn lint` échoue car une règle dans tslint.json n'est pas appliquée pour les fichiers js à la racine : `object-literal-sort-keys`
2. Exclusion du dossier `public`